### PR TITLE
Release update functionality for enums, exports and single file support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,5 +43,8 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
+      - name: Run Tests
+        run: composer run test
+
       - name: Run PHPStan
         run: composer run lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 ======
 
+# 2.2.0
+
+## Added
+
+- **useType option**: Generate TypeScript `type` aliases instead of `interface` declarations. Outputs `.ts` files instead of `.d.ts`.
+- **export option**: Add the `export` keyword before type/interface declarations for ES module compatibility.
+- **useEnumUnionType option**: Output PHP enums as TypeScript string literal union types (e.g., `type Status = 'active' | 'inactive';`).
+- **Enum support**: Automatically process PHP 8.1+ enums annotated with `#[TypeScript]` attribute.
+- **CLI options**: Added `--use-type`, `--export`, and `--enum-union-type` flags to both commands.
+- **PHPUnit test suite**: Added basic test infrastructure with configuration tests.
+
 # 2.0.0
 
 - Update dependency `paneon/php-to-typescript` to `^2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog
 - **Enum support**: Automatically process PHP 8.1+ enums annotated with `#[TypeScript]` attribute.
 - **CLI options**: Added `--use-type`, `--export`, and `--enum-union-type` flags to both commands.
 - **PHPUnit test suite**: Added basic test infrastructure with configuration tests.
+- **Single file mode**: Generate all TypeScript types into a single file instead of individual files per class/enum. Configure with `singleFileMode: true` and `singleFileOutput: 'types.ts'` or use `--single-file[=filename]` CLI option.
+- **Import resolution**: When using `export: true`, the generator now automatically adds `import` statements for referenced types. This enables proper TypeScript module resolution between generated files.
 
 # 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,76 @@ export type Example = {
 };
 ```
 
+## Import Resolution
+
+When using the `--export` option, the generator automatically adds `import` statements for referenced types. This enables proper TypeScript module resolution between generated files.
+
+For example, if you have a `User` class that references an `Address` class:
+
+```php
+<?php
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
+class User
+{
+    public string $name;
+    public Address $address;
+}
+```
+
+#### Output with --export (multi-file mode):
+
+```typescript
+// User.d.ts
+import { Address } from './Address';
+
+export interface User {
+    name: string;
+    address: Address;
+}
+```
+
+The import paths are automatically calculated based on the relative directory structure of the generated files.
+
+## Single File Mode
+
+Instead of generating individual files for each class/enum, you can output all TypeScript types into a single file using the `--single-file` option:
+
+```bash
+# Use default filename (types.ts)
+php bin/console typescript:generate --export --single-file
+
+# Specify custom filename
+php bin/console typescript:generate --export --single-file=all-types.ts
+```
+
+In single file mode:
+- All types are concatenated into a single output file
+- No `import` statements are generated (all types are in the same file)
+- Directory structure is not preserved
+
+#### Output with --export --single-file:
+
+```typescript
+// types.ts
+export interface Address {
+    street: string;
+    city: string;
+}
+
+export interface User {
+    name: string;
+    address: Address;
+}
+
+export enum Status {
+    Active = 'active',
+    Inactive = 'inactive',
+}
+```
+
 ## Enum Support
 
 PHP 8.1+ enums with the `#[TypeScript]` attribute are automatically processed alongside classes:
@@ -207,9 +277,11 @@ php_to_typescript:
     prefix: ''
     suffix: ''
     nullable: false
-    useType: false      # Generate type aliases instead of interfaces
-    export: false       # Add export keyword to declarations
+    useType: false           # Generate type aliases instead of interfaces
+    export: false            # Add export keyword to declarations
     useEnumUnionType: false  # Output enums as union types
+    singleFileMode: false    # Output all types to a single file
+    singleFileOutput: 'types.ts'  # Filename for single file mode
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -50,33 +50,18 @@ The default parameters will scan for alle PHP Classes inside "src/" and output t
 ```php
 <?php
 
-/**
- * @TypeScriptInterface
- */
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
 class Example
 {
-    /**
-     * @var string
-     */
-    public $firstName;
+    public string $firstName;
+    public ?string $middleName;
+    public string $lastName;
+    public ?int $age;
 
-    /**
-     * @var string|null
-     */
-    public $middleName;
-
-    /**
-     * @var string
-     */
-    public $lastName;
-
-    /**
-     * @var int|null
-     */
-    public $age;
-    
     /** @var Contact[] */
-    public $contacts;
+    public array $contacts;
 }
 ```
 
@@ -112,6 +97,121 @@ interface Example {
 }
 ```
 
+## Type Aliases instead of Interfaces
+
+Use the `--use-type` option to generate TypeScript `type` aliases instead of `interface` declarations. This will also change the output file extension from `.d.ts` to `.ts`:
+
+```bash
+php bin/console typescript:generate --use-type
+```
+
+#### Output with --use-type:
+
+```typescript
+type Example = {
+    firstName: string;
+    middleName: string;
+    lastName: string;
+    age: number;
+    contacts: Contact[];
+};
+```
+
+## Export Declarations
+
+Use the `--export` option to add the `export` keyword before declarations:
+
+```bash
+php bin/console typescript:generate --export
+```
+
+#### Output with --export:
+
+```typescript
+export interface Example {
+    firstName: string;
+    middleName: string;
+    lastName: string;
+    age: number;
+    contacts: Contact[];
+}
+```
+
+You can combine options:
+
+```bash
+php bin/console typescript:generate --export --use-type
+```
+
+#### Output with --export --use-type:
+
+```typescript
+export type Example = {
+    firstName: string;
+    middleName: string;
+    lastName: string;
+    age: number;
+    contacts: Contact[];
+};
+```
+
+## Enum Support
+
+PHP 8.1+ enums with the `#[TypeScript]` attribute are automatically processed alongside classes:
+
+```php
+<?php
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
+enum Status: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Pending = 'pending';
+}
+```
+
+#### Default enum output:
+
+```typescript
+enum Status {
+    Active = 'active',
+    Inactive = 'inactive',
+    Pending = 'pending',
+}
+```
+
+#### With --enum-union-type option:
+
+Use `--enum-union-type` to output enums as string literal union types:
+
+```bash
+php bin/console typescript:generate --enum-union-type
+```
+
+```typescript
+type Status = 'active' | 'inactive' | 'pending';
+```
+
+## Configuration Options
+
+You can configure these options in `config/packages/php_to_typescript.yaml`:
+
+```yaml
+php_to_typescript:
+    indentation: 2
+    inputDirectory: src/
+    outputDirectory: assets/js/interfaces/
+    prefix: ''
+    suffix: ''
+    nullable: false
+    useType: false      # Generate type aliases instead of interfaces
+    export: false       # Add export keyword to declarations
+    useEnumUnionType: false  # Output enums as union types
+```
+
 
 ## Usage of the Command 'typescript:generate-single'
 
@@ -122,5 +222,14 @@ It will only affect a single file and needs a specific target location if you do
 ```bash
 php bin/console typescript:generate-single vendor/some-package/src/SomeDir/DTO/SomeoneElsesClass.php assets/js/external/some-package/
 ```
+
+### Options for generate-single
+
+- `--nullable`: Include null types in output
+- `--use-type`: Generate type alias instead of interface
+- `--export`: Add export keyword before declaration
+- `--enum-union-type`: Output enums as union types
+
+The command automatically detects whether the file contains a class or enum and processes it accordingly.
 
 It's recommended to trigger the generation of interfaces after `composer update/install`.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "paneon/php-to-typescript-bundle",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "description": "Symfony-Bundle to use the PHP to Typescript library",
     "license": "MIT",
@@ -17,17 +17,11 @@
     ],
     "require": {
         "php": "^8.1",
-        "paneon/php-to-typescript": "dev-develop",
+        "paneon/php-to-typescript": "^2.2.0",
         "symfony/console": "*",
         "symfony/framework-bundle": "*",
         "symfony/monolog-bundle": "*"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Paneon/php-to-typescript.git"
-        }
-    ],
     "require-dev": {
         "phpstan/phpstan": "^1.2",
         "phpunit/phpunit": "^10.0"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "paneon/php-to-typescript-bundle",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "description": "Symfony-Bundle to use the PHP to Typescript library",
     "license": "MIT",
     "autoload": {
@@ -16,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "paneon/php-to-typescript": "^2.0",
+        "paneon/php-to-typescript": "dev-develop",
         "symfony/console": "*",
         "symfony/framework-bundle": "*",
         "symfony/monolog-bundle": "*"
@@ -28,7 +29,13 @@
         }
     ],
     "require-dev": {
-        "phpstan/phpstan": "^1.2"
+        "phpstan/phpstan": "^1.2",
+        "phpunit/phpunit": "^10.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Paneon\\PhpToTypeScriptBundle\\Tests\\": "tests/"
+        }
     },
     "scripts": {
         "build": [
@@ -36,6 +43,9 @@
         ],
         "lint": [
             "@php vendor/bin/phpstan analyze src --level=5"
+        ],
+        "test": [
+            "@php vendor/bin/phpunit"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "paneon/php-to-typescript": "^2.2.0",
         "symfony/console": "*",
         "symfony/framework-bundle": "*",
-        "symfony/monolog-bundle": "*"
+        "symfony/monolog-bundle": "*",
+        "nikic/php-parser": "^5.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "415db45a08fdf03485e040bfa735645f",
+    "content-hash": "95cecac26b760daa866b7c20a3818faf",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -169,16 +169,16 @@
         },
         {
             "name": "paneon/php-to-typescript",
-            "version": "dev-develop",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Paneon/php-to-typescript.git",
-                "reference": "9aeb20d7da75d91bcd07d658b42e6e1156ee7d39"
+                "reference": "034e399b048b7b5f16b8f985c0517963a15fe22c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Paneon/php-to-typescript/zipball/9aeb20d7da75d91bcd07d658b42e6e1156ee7d39",
-                "reference": "9aeb20d7da75d91bcd07d658b42e6e1156ee7d39",
+                "url": "https://api.github.com/repos/Paneon/php-to-typescript/zipball/034e399b048b7b5f16b8f985c0517963a15fe22c",
+                "reference": "034e399b048b7b5f16b8f985c0517963a15fe22c",
                 "shasum": ""
             },
             "require": {
@@ -195,24 +195,7 @@
                     "Paneon\\PhpToTypeScript\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Paneon\\PhpToTypeScript\\": "src/",
-                    "Paneon\\PhpToTypeScript\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "build": [
-                    "@lint",
-                    "@test"
-                ],
-                "lint": [
-                    "@php vendor/bin/phpstan analyze src --level=5"
-                ],
-                "test": [
-                    "vendor/bin/phpunit"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -224,10 +207,10 @@
             ],
             "description": "Generate TypeScript classes and interfaces based on PHP classes.",
             "support": {
-                "source": "https://github.com/Paneon/php-to-typescript/tree/develop",
-                "issues": "https://github.com/Paneon/php-to-typescript/issues"
+                "issues": "https://github.com/Paneon/php-to-typescript/issues",
+                "source": "https://github.com/Paneon/php-to-typescript/tree/v2.2.0"
             },
-            "time": "2026-01-21T17:47:07+00:00"
+            "time": "2026-01-22T13:02:50+00:00"
         },
         {
             "name": "psr/cache",
@@ -4435,10 +4418,8 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
-    "stability-flags": {
-        "paneon/php-to-typescript": 20
-    },
+    "minimum-stability": "stable",
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -173,12 +173,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Paneon/php-to-typescript.git",
-                "reference": "66b5a19d142b0795fe799bf0ef386dd2829993c4"
+                "reference": "9aeb20d7da75d91bcd07d658b42e6e1156ee7d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Paneon/php-to-typescript/zipball/66b5a19d142b0795fe799bf0ef386dd2829993c4",
-                "reference": "66b5a19d142b0795fe799bf0ef386dd2829993c4",
+                "url": "https://api.github.com/repos/Paneon/php-to-typescript/zipball/9aeb20d7da75d91bcd07d658b42e6e1156ee7d39",
+                "reference": "9aeb20d7da75d91bcd07d658b42e6e1156ee7d39",
                 "shasum": ""
             },
             "require": {
@@ -227,7 +227,7 @@
                 "source": "https://github.com/Paneon/php-to-typescript/tree/develop",
                 "issues": "https://github.com/Paneon/php-to-typescript/issues"
             },
-            "time": "2026-01-21T17:13:37+00:00"
+            "time": "2026-01-21T17:47:07+00:00"
         },
         {
             "name": "psr/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d4704b04d1326d9943cc8a98b385405",
+    "content-hash": "415db45a08fdf03485e040bfa735645f",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -169,16 +169,16 @@
         },
         {
             "name": "paneon/php-to-typescript",
-            "version": "v2.0.0",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Paneon/php-to-typescript.git",
-                "reference": "1d9715a71b8ceb6feb37c7fb90fdeb81ac704deb"
+                "reference": "66b5a19d142b0795fe799bf0ef386dd2829993c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Paneon/php-to-typescript/zipball/1d9715a71b8ceb6feb37c7fb90fdeb81ac704deb",
-                "reference": "1d9715a71b8ceb6feb37c7fb90fdeb81ac704deb",
+                "url": "https://api.github.com/repos/Paneon/php-to-typescript/zipball/66b5a19d142b0795fe799bf0ef386dd2829993c4",
+                "reference": "66b5a19d142b0795fe799bf0ef386dd2829993c4",
                 "shasum": ""
             },
             "require": {
@@ -224,10 +224,10 @@
             ],
             "description": "Generate TypeScript classes and interfaces based on PHP classes.",
             "support": {
-                "source": "https://github.com/Paneon/php-to-typescript/tree/v2.0.0",
+                "source": "https://github.com/Paneon/php-to-typescript/tree/develop",
                 "issues": "https://github.com/Paneon/php-to-typescript/issues"
             },
-            "time": "2026-01-16T12:10:30+00:00"
+            "time": "2026-01-21T17:13:37+00:00"
         },
         {
             "name": "psr/cache",
@@ -2770,6 +2770,184 @@
     ],
     "packages-dev": [
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.12.32",
             "dist": {
@@ -2821,12 +2999,1447 @@
                 }
             ],
             "time": "2025-09-30T10:16:31+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.60",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "f2e26f52f80ef77832e359205f216eeac00e320c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f2e26f52f80ef77832e359205f216eeac00e320c",
+                "reference": "f2e26f52f80ef77832e359205f216eeac00e320c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.60"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-06T07:50:42+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": {},
-    "prefer-stable": false,
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "paneon/php-to-typescript": 20
+    },
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95cecac26b760daa866b7c20a3818faf",
+    "content-hash": "40cad83bbbc15e89ffafc579276c5d4f",
     "packages": [
         {
             "name": "monolog/monolog",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+>
+    <testsuites>
+        <testsuite name="PhpToTypeScriptBundle Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Command/GenerateCommandSingle.php
+++ b/src/Command/GenerateCommandSingle.php
@@ -65,6 +65,24 @@ class GenerateCommandSingle extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Whether or not to use Null-aware types for TS v2 and later',
                 false
+            )
+            ->addOption(
+                'use-type',
+                null,
+                InputOption::VALUE_NONE,
+                'Generate "type" instead of "interface" (outputs .ts instead of .d.ts)'
+            )
+            ->addOption(
+                'export',
+                null,
+                InputOption::VALUE_NONE,
+                'Add "export" keyword before declarations'
+            )
+            ->addOption(
+                'enum-union-type',
+                null,
+                InputOption::VALUE_NONE,
+                'Output enums as string literal union types'
             );
     }
 
@@ -79,6 +97,9 @@ class GenerateCommandSingle extends Command
         $suffix = $input->getArgument('suffix');
         $indent = $input->getArgument('indent');
         $includeTypeNullable = $input->getOption('nullable') !== false;
+        $useType = $input->getOption('use-type');
+        $export = $input->getOption('export');
+        $enumUnionType = $input->getOption('enum-union-type');
 
         if ($outputDir[-1] !== DIRECTORY_SEPARATOR) {
             $outputDir .= DIRECTORY_SEPARATOR;
@@ -87,25 +108,31 @@ class GenerateCommandSingle extends Command
         if ($includeTypeNullable) {
             $this->parserService->setIncludeTypeNullable($includeTypeNullable);
         }
+        if ($useType) {
+            $this->parserService->setUseType(true);
+        }
+        if ($export) {
+            $this->parserService->setExport(true);
+        }
+        if ($enumUnionType) {
+            $this->parserService->setUseEnumUnionType(true);
+        }
 
         $targetFile = $outputDir . $this->parserService->getOutputFileName($sourceFileName);
 
         $output->writeln('Generating files...');
 
-        if($prefix){
+        if ($prefix) {
             $this->parserService->setPrefix($prefix);
         }
-        if($suffix){
+        if ($suffix) {
             $this->parserService->setSuffix($suffix);
         }
-        if($indent){
+        if ($indent) {
             $this->parserService->setIndent($indent);
         }
 
-        $content = $this->parserService->getInterfaceContent(
-            $sourceFileName,
-            false
-        );
+        $content = $this->parserService->getContent($sourceFileName, false);
 
         if ($content) {
             $this->fs->dumpFile($targetFile, $content);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,6 +35,8 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('useType')->defaultValue(false)->end()
                 ->booleanNode('export')->defaultValue(false)->end()
                 ->booleanNode('useEnumUnionType')->defaultValue(false)->end()
+                ->booleanNode('singleFileMode')->defaultValue(false)->end()
+                ->scalarNode('singleFileOutput')->defaultValue('types.ts')->end()
             ->end();
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,6 +32,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('prefix')->defaultValue('')->end()
                 ->scalarNode('suffix')->defaultValue('')->end()
                 ->booleanNode('nullable')->defaultValue(false)->end()
+                ->booleanNode('useType')->defaultValue(false)->end()
+                ->booleanNode('export')->defaultValue(false)->end()
+                ->booleanNode('useEnumUnionType')->defaultValue(false)->end()
             ->end();
     }
 

--- a/src/DependencyInjection/PhpToTypeScriptExtension.php
+++ b/src/DependencyInjection/PhpToTypeScriptExtension.php
@@ -37,6 +37,8 @@ class PhpToTypeScriptExtension extends Extension
         $container->setParameter('type_script_generator.useType', $config['useType']);
         $container->setParameter('type_script_generator.export', $config['export']);
         $container->setParameter('type_script_generator.useEnumUnionType', $config['useEnumUnionType']);
+        $container->setParameter('type_script_generator.singleFileMode', $config['singleFileMode']);
+        $container->setParameter('type_script_generator.singleFileOutput', $config['singleFileOutput']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');

--- a/src/DependencyInjection/PhpToTypeScriptExtension.php
+++ b/src/DependencyInjection/PhpToTypeScriptExtension.php
@@ -34,6 +34,9 @@ class PhpToTypeScriptExtension extends Extension
         $container->setParameter('type_script_generator.inputDirectory', $config['inputDirectory']);
         $container->setParameter('type_script_generator.outputDirectory', $config['outputDirectory']);
         $container->setParameter('type_script_generator.nullable', $config['nullable']);
+        $container->setParameter('type_script_generator.useType', $config['useType']);
+        $container->setParameter('type_script_generator.export', $config['export']);
+        $container->setParameter('type_script_generator.useEnumUnionType', $config['useEnumUnionType']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -17,6 +17,9 @@ services:
         $inputDirectory: '%type_script_generator.inputDirectory%'
         $outputDirectory: '%type_script_generator.outputDirectory%'
         $nullable: '%type_script_generator.nullable%'
+        $useType: '%type_script_generator.useType%'
+        $export: '%type_script_generator.export%'
+        $useEnumUnionType: '%type_script_generator.useEnumUnionType%'
 
   Paneon\PhpToTypeScriptBundle\Command\GenerateCommandSingle:
       public: true

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -20,6 +20,8 @@ services:
         $useType: '%type_script_generator.useType%'
         $export: '%type_script_generator.export%'
         $useEnumUnionType: '%type_script_generator.useEnumUnionType%'
+        $singleFileMode: '%type_script_generator.singleFileMode%'
+        $singleFileOutput: '%type_script_generator.singleFileOutput%'
 
   Paneon\PhpToTypeScriptBundle\Command\GenerateCommandSingle:
       public: true

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -1,0 +1,454 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\Command;
+
+use Paneon\PhpToTypeScript\Parser\PhpDocParser;
+use Paneon\PhpToTypeScript\Services\ParserService;
+use Paneon\PhpToTypeScriptBundle\Command\GenerateCommand;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class GenerateCommandTest extends TestCase
+{
+    private string $outputDir;
+    private Filesystem $fs;
+    private ParserService $parserService;
+
+    protected function setUp(): void
+    {
+        $this->outputDir = sys_get_temp_dir() . '/php-to-typescript-test-' . uniqid();
+        $this->fs = new Filesystem();
+        $this->fs->mkdir($this->outputDir);
+
+        $this->parserService = new ParserService(
+            new NullLogger(),
+            new PhpDocParser()
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->fs->exists($this->outputDir)) {
+            $this->fs->remove($this->outputDir);
+        }
+    }
+
+    public function testMultiFileModeGeneratesIndividualFiles(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Verify individual files were created
+        $this->assertFileExists($this->outputDir . '/SampleClass.d.ts');
+        $this->assertFileExists($this->outputDir . '/SampleEnum.d.ts');
+        $this->assertFileExists($this->outputDir . '/Address.d.ts');
+        $this->assertFileExists($this->outputDir . '/User.d.ts');
+        $this->assertFileExists($this->outputDir . '/Nested/Company.d.ts');
+
+        // Verify single file was not created
+        $this->assertFileDoesNotExist($this->outputDir . '/types.ts');
+    }
+
+    public function testSingleFileModeGeneratesOneFile(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            true, // export
+            false,
+            true, // singleFileMode
+            'all-types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Verify single file was created
+        $this->assertFileExists($this->outputDir . '/all-types.ts');
+
+        // Read and verify content contains all types
+        $content = file_get_contents($this->outputDir . '/all-types.ts');
+        $this->assertStringContainsString('SampleClass', $content);
+        $this->assertStringContainsString('SampleEnum', $content);
+        $this->assertStringContainsString('Address', $content);
+        $this->assertStringContainsString('User', $content);
+        $this->assertStringContainsString('Company', $content);
+
+        // Verify individual files were not created
+        $this->assertFileDoesNotExist($this->outputDir . '/SampleClass.d.ts');
+    }
+
+    public function testSingleFileModeViaCommandLineOption(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            false, // singleFileMode disabled in config
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--single-file' => 'bundle.ts',
+        ]);
+
+        // Verify single file was created with CLI-specified name
+        $this->assertFileExists($this->outputDir . '/bundle.ts');
+    }
+
+    public function testSingleFileModeWithDefaultFilename(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--single-file' => null, // Use default filename
+        ]);
+
+        // Verify single file was created with default name
+        $this->assertFileExists($this->outputDir . '/types.ts');
+    }
+
+    public function testExportKeywordIsAdded(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            true, // export
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Read generated file and verify export keyword
+        $content = file_get_contents($this->outputDir . '/SampleClass.d.ts');
+        $this->assertStringContainsString('export', $content);
+    }
+
+    public function testExportKeywordViaCommandLineOption(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false, // export disabled in config
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            '--export' => true,
+        ]);
+
+        // Read generated file and verify export keyword
+        $content = file_get_contents($this->outputDir . '/SampleClass.d.ts');
+        $this->assertStringContainsString('export', $content);
+    }
+
+    public function testUseTypeGeneratesTsExtension(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            true, // useType
+            false,
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Verify .ts files were created instead of .d.ts
+        $this->assertFileExists($this->outputDir . '/SampleClass.ts');
+        $this->assertFileDoesNotExist($this->outputDir . '/SampleClass.d.ts');
+    }
+
+    public function testPrefixAndSuffix(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            'I',
+            'Type',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Verify files with prefix and suffix were created
+        $this->assertFileExists($this->outputDir . '/ISampleClassType.d.ts');
+    }
+
+    public function testNestedDirectoryStructureIsPreserved(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Verify nested directory structure
+        $this->assertFileExists($this->outputDir . '/Nested/Company.d.ts');
+    }
+
+    public function testSingleFileModeWithExportHasNoImports(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            true, // export
+            false,
+            true, // singleFileMode
+            'all-types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        // Read single file and verify no import statements
+        $content = file_get_contents($this->outputDir . '/all-types.ts');
+        $this->assertStringNotContainsString('import ', $content);
+    }
+
+    public function testCommandOutputShowsProgress(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            false,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Processing directory:', $output);
+        $this->assertStringContainsString('...done!', $output);
+    }
+
+    public function testSingleFileModeOutputShowsProgress(): void
+    {
+        $inputDir = __DIR__ . '/../Fixtures/';
+
+        $command = new GenerateCommand(
+            $this->parserService,
+            $this->fs,
+            [],
+            '',
+            '',
+            2,
+            false,
+            $inputDir,
+            $this->outputDir,
+            [],
+            false,
+            false,
+            false,
+            true,
+            'types.ts'
+        );
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Generating single file:', $output);
+        $this->assertStringContainsString('...done!', $output);
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\DependencyInjection;
+
+use Paneon\PhpToTypeScriptBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends TestCase
+{
+    public function testDefaultConfiguration(): void
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, []);
+
+        $this->assertSame(2, $config['indentation']);
+        $this->assertSame('src/', $config['inputDirectory']);
+        $this->assertSame('assets/js/interfaces/', $config['outputDirectory']);
+        $this->assertSame('', $config['prefix']);
+        $this->assertSame('', $config['suffix']);
+        $this->assertFalse($config['nullable']);
+        $this->assertFalse($config['useType']);
+        $this->assertFalse($config['export']);
+        $this->assertFalse($config['useEnumUnionType']);
+    }
+
+    public function testCustomConfiguration(): void
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, [
+            [
+                'indentation' => 4,
+                'inputDirectory' => 'app/',
+                'outputDirectory' => 'public/js/types/',
+                'prefix' => 'I',
+                'suffix' => 'Type',
+                'nullable' => true,
+                'useType' => true,
+                'export' => true,
+                'useEnumUnionType' => true,
+            ]
+        ]);
+
+        $this->assertSame(4, $config['indentation']);
+        $this->assertSame('app/', $config['inputDirectory']);
+        $this->assertSame('public/js/types/', $config['outputDirectory']);
+        $this->assertSame('I', $config['prefix']);
+        $this->assertSame('Type', $config['suffix']);
+        $this->assertTrue($config['nullable']);
+        $this->assertTrue($config['useType']);
+        $this->assertTrue($config['export']);
+        $this->assertTrue($config['useEnumUnionType']);
+    }
+
+    public function testPartialConfiguration(): void
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, [
+            [
+                'useType' => true,
+                'export' => true,
+            ]
+        ]);
+
+        // New options should be set
+        $this->assertTrue($config['useType']);
+        $this->assertTrue($config['export']);
+
+        // Other options should keep defaults
+        $this->assertFalse($config['useEnumUnionType']);
+        $this->assertFalse($config['nullable']);
+        $this->assertSame(2, $config['indentation']);
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -25,6 +25,8 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($config['useType']);
         $this->assertFalse($config['export']);
         $this->assertFalse($config['useEnumUnionType']);
+        $this->assertFalse($config['singleFileMode']);
+        $this->assertSame('types.ts', $config['singleFileOutput']);
     }
 
     public function testCustomConfiguration(): void
@@ -42,6 +44,8 @@ class ConfigurationTest extends TestCase
                 'useType' => true,
                 'export' => true,
                 'useEnumUnionType' => true,
+                'singleFileMode' => true,
+                'singleFileOutput' => 'all-types.ts',
             ]
         ]);
 
@@ -54,6 +58,8 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($config['useType']);
         $this->assertTrue($config['export']);
         $this->assertTrue($config['useEnumUnionType']);
+        $this->assertTrue($config['singleFileMode']);
+        $this->assertSame('all-types.ts', $config['singleFileOutput']);
     }
 
     public function testPartialConfiguration(): void
@@ -75,5 +81,36 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($config['useEnumUnionType']);
         $this->assertFalse($config['nullable']);
         $this->assertSame(2, $config['indentation']);
+        $this->assertFalse($config['singleFileMode']);
+        $this->assertSame('types.ts', $config['singleFileOutput']);
+    }
+
+    public function testSingleFileModeConfiguration(): void
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, [
+            [
+                'singleFileMode' => true,
+            ]
+        ]);
+
+        $this->assertTrue($config['singleFileMode']);
+        $this->assertSame('types.ts', $config['singleFileOutput']);
+    }
+
+    public function testSingleFileOutputWithoutMode(): void
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $config = $processor->processConfiguration($configuration, [
+            [
+                'singleFileOutput' => 'bundle.ts',
+            ]
+        ]);
+
+        // singleFileMode should still be false, but output filename should be set
+        $this->assertFalse($config['singleFileMode']);
+        $this->assertSame('bundle.ts', $config['singleFileOutput']);
     }
 }

--- a/tests/Fixtures/Address.php
+++ b/tests/Fixtures/Address.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\Fixtures;
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
+class Address
+{
+    public string $street;
+    public string $city;
+    public string $zipCode;
+    public string $country;
+}

--- a/tests/Fixtures/Nested/Company.php
+++ b/tests/Fixtures/Nested/Company.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\Fixtures\Nested;
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+use Paneon\PhpToTypeScriptBundle\Tests\Fixtures\Address;
+
+#[TypeScript]
+class Company
+{
+    public string $name;
+    public Address $headquarters;
+}

--- a/tests/Fixtures/SampleClass.php
+++ b/tests/Fixtures/SampleClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\Fixtures;
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
+class SampleClass
+{
+    public string $name;
+    public int $age;
+    public ?string $email;
+}

--- a/tests/Fixtures/SampleEnum.php
+++ b/tests/Fixtures/SampleEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\Fixtures;
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
+enum SampleEnum: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Pending = 'pending';
+}

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paneon\PhpToTypeScriptBundle\Tests\Fixtures;
+
+use Paneon\PhpToTypeScript\Attribute\TypeScript;
+
+#[TypeScript]
+class User
+{
+    public string $name;
+    public string $email;
+    public ?Address $address;
+    public SampleEnum $status;
+}


### PR DESCRIPTION
- **useType option**: Generate TypeScript `type` aliases instead of `interface` declarations. Outputs `.ts` files instead of `.d.ts`.
- **export option**: Add the `export` keyword before type/interface declarations for ES module compatibility.
- **useEnumUnionType option**: Output PHP enums as TypeScript string literal union types (e.g., `type Status = 'active' | 'inactive';`).
- **Enum support**: Automatically process PHP 8.1+ enums annotated with `#[TypeScript]` attribute.
- **CLI options**: Added `--use-type`, `--export`, and `--enum-union-type` flags to both commands.
- **PHPUnit test suite**: Added basic test infrastructure with configuration tests.